### PR TITLE
[intesis] Session Handling improved

### DIFF
--- a/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/gson/IntesisHomeJSonDTO.java
+++ b/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/gson/IntesisHomeJSonDTO.java
@@ -25,6 +25,7 @@ public class IntesisHomeJSonDTO {
     public static class Response {
         public boolean success;
         public JsonElement data;
+        public JsonElement error;
     }
 
     public static class Data {
@@ -34,6 +35,11 @@ public class IntesisHomeJSonDTO {
         public JsonElement config;
         public JsonElement dp;
         public JsonElement dpval;
+    }
+
+    public static class ResponseError {
+        public int code;
+        public String message;
     }
 
     public static class Id {

--- a/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/handler/IntesisHomeHandler.java
+++ b/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/handler/IntesisHomeHandler.java
@@ -41,6 +41,7 @@ import org.openhab.binding.intesis.internal.gson.IntesisHomeJSonDTO.Dpval;
 import org.openhab.binding.intesis.internal.gson.IntesisHomeJSonDTO.Id;
 import org.openhab.binding.intesis.internal.gson.IntesisHomeJSonDTO.Info;
 import org.openhab.binding.intesis.internal.gson.IntesisHomeJSonDTO.Response;
+import org.openhab.binding.intesis.internal.gson.IntesisHomeJSonDTO.ResponseError;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
 import org.openhab.core.library.types.QuantityType;
@@ -86,6 +87,8 @@ public class IntesisHomeHandler extends BaseThingHandler {
 
     private IntesisHomeConfiguration config = new IntesisHomeConfiguration();
 
+    private String sessionId = "";
+
     private @Nullable ScheduledFuture<?> refreshJob;
 
     public IntesisHomeHandler(final Thing thing, final HttpClient httpClient,
@@ -111,6 +114,8 @@ public class IntesisHomeHandler extends BaseThingHandler {
         } else {
             // start background initialization:
             scheduler.submit(() -> {
+                logger.trace("initialize() - trying to log in");
+                login();
                 populateProperties();
                 // query available dataPoints and build dynamic channels
                 postRequestInSession(sessionId -> "{\"command\":\"getavailabledatapoints\",\"data\":{\"sessionID\":\""
@@ -129,6 +134,11 @@ public class IntesisHomeHandler extends BaseThingHandler {
             refreshJob.cancel(true);
             this.refreshJob = null;
         }
+
+        // start background dispose:
+        scheduler.submit(() -> {
+            logout();
+        });
     }
 
     @Override
@@ -216,31 +226,40 @@ public class IntesisHomeHandler extends BaseThingHandler {
     }
 
     public @Nullable String login() {
-        // lambda's can't modify local variables, so we use an array here to get around the issue
-        String[] sessionId = new String[1];
         postRequest(
                 "{\"command\":\"login\",\"data\":{\"username\":\"Admin\",\"password\":\"" + config.password + "\"}}",
                 resp -> {
                     Data data = gson.fromJson(resp.data, Data.class);
+                    ResponseError error = gson.fromJson(resp.error, ResponseError.class);
+                    if (error != null) {
+                        logger.debug("login() - error: {}", error);
+                    }
                     if (data != null) {
                         Id id = gson.fromJson(data.id, Id.class);
                         if (id != null) {
-                            sessionId[0] = id.sessionID;
+                            sessionId = id.sessionID.toString();
                         }
                     }
                 });
-        if (sessionId[0] != null && !sessionId[0].isEmpty()) {
+        logger.trace("login() - received session ID: {}", sessionId);
+        if (sessionId != null && !sessionId.isEmpty()) {
             updateStatus(ThingStatus.ONLINE);
-            return sessionId[0];
         } else {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "SessionId not received");
-            return null;
+            sessionId = "";
         }
+        return sessionId;
     }
 
-    public @Nullable String logout(String sessionId) {
-        String contentString = "{\"command\":\"logout\",\"data\":{\"sessionID\":\"" + sessionId + "\"}}";
-        return api.postRequest(config.ipAddress, contentString);
+    public @Nullable String logout() {
+        if (!sessionId.isEmpty()) { // we have a running session
+            String contentString = "{\"command\":\"logout\",\"data\":{\"sessionID\":\"" + sessionId + "\"}}";
+            logger.trace("logout() - session ID: {}", sessionId);
+            sessionId = ""; // not really necessary as it is called after dispose(), so sessionID is not used anympre,
+                            // but it is a cleaner way
+            return api.postRequest(config.ipAddress, contentString);
+        }
+        return null;
     }
 
     public void populateProperties() {
@@ -309,18 +328,34 @@ public class IntesisHomeHandler extends BaseThingHandler {
     }
 
     private void postRequest(String request, Consumer<Response> handler) {
+        postRequest(request, handler, false);
+    }
+
+    private void postRequest(String request, Consumer<Response> handler, boolean retry) {
         try {
             logger.trace("request : '{}'", request);
             String response = api.postRequest(config.ipAddress, request);
             if (response != null) {
                 Response resp = gson.fromJson(response, Response.class);
                 if (resp != null) {
-                    boolean success = resp.success;
-                    if (success) {
+                    if (resp.success) {
                         handler.accept(resp);
                     } else {
                         updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                                 "Request unsuccessful");
+                        ResponseError respError = gson.fromJson(resp.error, ResponseError.class);
+                        if (respError != null) {
+                            logger.warn("postRequest failed - respErrorCode: {} / respErrorMessage: {} / retry {}",
+                                    respError.code, respError.message, retry);
+                            if (!retry && respError.code == 1) {
+                                logger.debug(
+                                        "postRequest: trying to log in and retry request - respErrorCode: {} / respErrorMessage: {} / retry {}",
+                                        respError.code, respError.message, retry);
+                                login();
+                                postRequest(request, handler, true);
+                            }
+                        }
+
                     }
                 }
             } else {
@@ -332,13 +367,11 @@ public class IntesisHomeHandler extends BaseThingHandler {
     }
 
     private void postRequestInSession(UnaryOperator<String> requestFactory, Consumer<Response> handler) {
-        String sessionId = login();
         if (sessionId != null) {
             try {
                 String request = requestFactory.apply(sessionId);
                 postRequest(request, handler);
             } finally {
-                logout(sessionId);
             }
         }
     }


### PR DESCRIPTION
I have changed the login process so that the binding now only logs in at the beginning and logs out at the end of the lifetime. If a request fails due to a missing login or an invalid session ID, a new login attempt is made.

This ensures that
- Several requests can be sent in direct succession (if I switch the air conditioning from cooling to heating, I also want to change the slats at the same time)
- Less traffic is generated as there is not a constant logout and login again
- Ideally, the login credentials should only be visible once at startup

This change fixes #15502.

Signed-off-by: Christoph <fd0cwp@gmx.de>