### PR TITLE
[intesis] Session Handling improved

### DIFF
--- a/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/handler/IntesisHomeHandler.java
+++ b/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/handler/IntesisHomeHandler.java
@@ -117,6 +117,8 @@ public class IntesisHomeHandler extends BaseThingHandler {
 
             // start background initialization:
             scheduler.submit(() -> {
+                logger.trace("initialize() - trying to log in");
+                login();
                 populateProperties();
                 // query available dataPoints and build dynamic channels
                 postRequestInSession(sessionId -> "{\"command\":\"getavailabledatapoints\",\"data\":{\"sessionID\":\""
@@ -136,7 +138,10 @@ public class IntesisHomeHandler extends BaseThingHandler {
             this.refreshJob = null;
         }
 
-        logout(sessionId);
+        // start background dispose:
+        scheduler.submit(() -> {
+            logout();
+        });
     }
 
     @Override
@@ -230,7 +235,7 @@ public class IntesisHomeHandler extends BaseThingHandler {
                     Data data = gson.fromJson(resp.data, Data.class);
                     ResponseError error = gson.fromJson(resp.error, ResponseError.class);
                     if (error != null) {
-                        logger.debug("Login - Error: {}", error);
+                        logger.debug("login() - error: {}", error);
                     }
                     if (data != null) {
                         Id id = gson.fromJson(data.id, Id.class);
@@ -239,7 +244,7 @@ public class IntesisHomeHandler extends BaseThingHandler {
                         }
                     }
                 });
-        logger.trace("Login - received session ID: {}", sessionId);
+        logger.trace("login() - received session ID: {}", sessionId);
         if (sessionId != null && !sessionId.isEmpty()) {
             updateStatus(ThingStatus.ONLINE);
         } else {
@@ -249,9 +254,15 @@ public class IntesisHomeHandler extends BaseThingHandler {
         return sessionId;
     }
 
-    public @Nullable String logout(String sessionId) {
-        String contentString = "{\"command\":\"logout\",\"data\":{\"sessionID\":\"" + sessionId + "\"}}";
-        return api.postRequest(config.ipAddress, contentString);
+    public @Nullable String logout() {
+        if (!sessionId.isEmpty()) { // we have a running session
+            String contentString = "{\"command\":\"logout\",\"data\":{\"sessionID\":\"" + sessionId + "\"}}";
+            logger.trace("logout() - session ID: {}", sessionId);
+            sessionId = ""; // not really necessary as it is called after dispose(), so sessionID is not used anympre,
+                            // but it is a cleaner way
+            return api.postRequest(config.ipAddress, contentString);
+        }
+        return null;
     }
 
     public void populateProperties() {


### PR DESCRIPTION
I have changed the login process so that the binding now only logs in at the beginning and logs out at the end of the lifetime. If a request fails due to a missing login or an invalid session ID, a new login attempt is made.

This ensures that
- Several requests can be sent in direct succession (if I switch the air conditioning from cooling to heating, I also want to change the slats at the same time)
- Less traffic is generated as there is not a constant logout and login again
- Ideally, the login credentials should only be visible once at startup

This change fixes #15502.

Signed-off-by: Christoph <fd0cwp@gmx.de>