### PR TITLE
[intesis] Session Handling improved

### DIFF
--- a/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/handler/IntesisHomeHandler.java
+++ b/bundles/org.openhab.binding.intesis/src/main/java/org/openhab/binding/intesis/internal/handler/IntesisHomeHandler.java
@@ -112,9 +112,6 @@ public class IntesisHomeHandler extends BaseThingHandler {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Password not set");
             return;
         } else {
-            logger.trace("trying to log in - current session ID: {}", sessionId);
-            login();
-
             // start background initialization:
             scheduler.submit(() -> {
                 logger.trace("initialize() - trying to log in");


### PR DESCRIPTION
I have changed the login process so that the binding now only logs in at the beginning and logs out at the end of the lifetime. If a request fails due to a missing login or an invalid session ID, a new login attempt is made.

This ensures that
- Several requests can be sent in direct succession (if I switch the air conditioning from cooling to heating, I also want to change the slats at the same time)
- Less traffic is generated as there is not a constant logout and login again
- Ideally, the login credentials should only be visible once at startup

This change fixes #15502.

Signed-off-by: Christoph <fd0cwp@gmx.de>